### PR TITLE
[Phase2 sandbox trial] buddy_list: use ::before for idle status circle

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -169,6 +169,19 @@
         font-size: 0.5333em;
     }
 
+    /* Move idle circle gradient onto ::before so the icon container can
+       have a solid background when needed. */
+    .user-circle-idle {
+        background: var(--color-background);
+    }
+
+    .user-circle-idle::before {
+        background: var(--gradient-user-circle-idle);
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        border-radius: 50%;
+    }
+
     .user_sidebar_entry.with_avatar {
         .user-profile-picture-container {
             /* Establish positioning context for user circle. */
@@ -203,6 +216,10 @@
                a 1px border, especially at smaller font sizes. */
             border: 1.5px solid var(--color-background);
             border-radius: 50%;
+
+            &.user-circle-idle::before {
+                background: var(--gradient-user-circle-idle-avatar);
+            }
 
             &.user-circle-offline {
                 display: none;


### PR DESCRIPTION
## Phase2 sandbox trial (fork-only)

Implements a minimal sandbox change for upstream issue zulip/zulip#37031.

### What changed
- Move right-sidebar idle status-circle gradient styling onto the pseudo-element ::before.
- Keep icon container background solid for better rendering with bordered/over-avatar circles.
- Add avatar variant override to keep using the --gradient-user-circle-idle-avatar variable.

### Scope
- Files changed: 1
- Net lines: +17 / -0

### Validation
- git diff --check passes.
- Full Zulip stylelint/dev checks are not runnable in this checkout because Zulip dev environment (.venv) is not present.

Upstream repository was not modified; this PR is fork-internal only.