### PR TITLE
right sidebar: style idle presence icon via ::before

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -169,6 +169,20 @@
         font-size: 0.5333em;
     }
 
+    /* Mirror the typeahead pattern by applying idle gradients to the icon
+       pseudo-element, not the wrapper element. */
+    .user-circle-idle {
+        background: none;
+        -webkit-text-fill-color: inherit;
+    }
+
+    .user-circle-idle::before {
+        background: var(--gradient-user-circle-idle);
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        border-radius: 50%;
+    }
+
     .user_sidebar_entry.with_avatar {
         .user-profile-picture-container {
             /* Establish positioning context for user circle. */
@@ -206,6 +220,10 @@
 
             &.user-circle-offline {
                 display: none;
+            }
+
+            &.user-circle-idle::before {
+                background: var(--gradient-user-circle-idle-avatar);
             }
         }
     }


### PR DESCRIPTION
## Summary
Use the right-sidebar presence circle pattern that applies idle gradients on the icon pseudo-element (::before) instead of the wrapper element.

## Changes
- Add right-sidebar-specific .user-circle-idle::before gradient styling.
- Reset wrapper-level idle styling in right sidebar to avoid conflicting background behavior.
- Use avatar-specific idle gradient token for .with_avatar circles.

## Validation
- git diff --check
- Attempted ./tools/lint --only frontend --files web/styles/right_sidebar.css (blocked: not in Zulip dev environment)

Fixes #2