### PR TITLE
presence: clear stale deactivated circle classes

### DIFF
--- a/web/src/buddy_list_presence.ts
+++ b/web/src/buddy_list_presence.ts
@@ -17,6 +17,7 @@ export function update_indicators(): void {
                 user-circle-active zulip-icon-user-circle-active
                 user-circle-idle zulip-icon-user-circle-idle
                 user-circle-offline zulip-icon-user-circle-offline
+                user-circle-deactivated zulip-icon-user-circle-deactivated
             `,
             )
             .addClass(user_circle_class_with_icon);

--- a/web/tests/buddy_list_presence.test.cjs
+++ b/web/tests/buddy_list_presence.test.cjs
@@ -1,0 +1,27 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+const $ = require("./lib/zjquery.cjs");
+
+const buddy_data = mock_esm("../src/buddy_data.ts");
+const people = mock_esm("../src/people.ts");
+
+const buddy_list_presence = zrequire("buddy_list_presence");
+
+run_test("update_indicators clears deactivated classes", ({override}) => {
+    override(people, "is_active_user_or_system_bot", () => true);
+    override(buddy_data, "get_user_circle_class", () => "user-circle-active");
+
+    const $presence = $.create("[data-presence-indicator-user-id='10']");
+    $presence.addClass("user-circle-deactivated zulip-icon-user-circle-deactivated");
+
+    buddy_list_presence.update_indicators();
+
+    assert.equal($presence.hasClass("user-circle-deactivated"), false);
+    assert.equal($presence.hasClass("zulip-icon-user-circle-deactivated"), false);
+    assert.equal($presence.hasClass("user-circle-active"), true);
+    assert.equal($presence.hasClass("zulip-icon-user-circle-active"), true);
+});


### PR DESCRIPTION
## Summary
Ensure buddy_list_presence.update_indicators removes deactivated presence classes before adding the new state.

## Changes
- Remove user-circle-deactivated and zulip-icon-user-circle-deactivated in the reset class list.
- Add frontend unit test coverage for the deactivated -> active transition.

## Validation
- bash -l -c "node -v && node --check web/tests/buddy_list_presence.test.cjs && git diff --check"
- Attempted: ./tools/test-js-with-node web/tests/buddy_list_presence.test.cjs (blocked: Zulip dev environment/.venv missing)

Fixes #4