### PR TITLE
presence: let self status reflect idle when available

### DIFF
--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -68,17 +68,21 @@ export function clear_internal_data(): void {
 const BIG_REALM_COUNT = 250;
 
 export function get_status(user_id: number): PresenceStatus["status"] {
-    if (people.is_my_user_id(user_id)) {
-        if (user_settings.presence_enabled) {
-            // if the current user is sharing presence, they always see themselves as online.
-            return "active";
-        }
+    if (people.is_my_user_id(user_id) && !user_settings.presence_enabled) {
         // if the current user is not sharing presence, they always see themselves as offline.
         return "offline";
     }
+
     if (presence_info.has(user_id)) {
         return presence_info.get(user_id)!.status;
     }
+
+    if (people.is_my_user_id(user_id)) {
+        // We may not always have freshly populated presence_info for self on initial load.
+        // Keep the previous UX fallback in that case.
+        return "active";
+    }
+
     return "offline";
 }
 

--- a/web/tests/presence.test.cjs
+++ b/web/tests/presence.test.cjs
@@ -271,6 +271,9 @@ test("get_status", ({override}) => {
     override(user_settings, "presence_enabled", true);
     assert.equal(presence.get_status(current_user.user_id), "active");
 
+    presence.presence_info.set(current_user.user_id, {status: "idle"});
+    assert.equal(presence.get_status(current_user.user_id), "idle");
+
     presence.presence_info.delete(zoe.user_id);
     assert.equal(presence.get_status(zoe.user_id), "offline");
 


### PR DESCRIPTION
## Summary
Allow the current user to see the same status that others see when presence data marks them idle.

## Changes
- In get_status, only force self to offline when presence sharing is disabled.
- Prefer actual presence_info status for self when available.
- Keep active fallback for self if presence_info is not loaded yet.
- Add a frontend test assertion that self status returns idle when presence_info says idle.

## Validation
- bash -l -c "node --check web/tests/presence.test.cjs && git diff --check"
- Attempted: ./tools/test-js-with-node web/tests/presence.test.cjs (blocked: Zulip dev environment/.venv missing)

Fixes #6