### PR TITLE
fix(sandbox): ruff-c408 [corporate/views/remote_activity.py]

### DIFF
--- a/corporate/views/remote_activity.py
+++ b/corporate/views/remote_activity.py
@@ -281,5 +281,5 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
     return render(
         request,
         "corporate/activity/activity.html",
-        context=dict(data=content, title=title, is_home=False),
+        context={"data": content, "title": title, "is_home": False},
     )


### PR DESCRIPTION
Automated sandbox autofix PR.

[finding_id:2942104e94dce645312f67bc52139651a1c812232e75dc1b9926c23b75e10e5c]
- dedupe_key: 2942104e94dce645312f67bc52139651a1c812232e75dc1b9926c23b75e10e5c
- rule: ruff-c408
- file: corporate/views/remote_activity.py:284
Fixes #47

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies a single automated ruff C408 fix in `corporate/views/remote_activity.py`, replacing an unnecessary `dict()` constructor call with an equivalent dict literal in the `get_remote_server_activity` view's `render()` call. The change is purely stylistic — the two forms are semantically identical in Python — and it aligns the file with the project's ruff linting rules.

**Changes:**
- Line 284: `dict(data=content, title=title, is_home=False)` → `{"data": content, "title": title, "is_home": False}`

No functional or behavioral impact; the rendered template context is unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a one-line automated style fix with no functional impact.
- The change is a direct, mechanically equivalent substitution of `dict()` with a dict literal. No logic, data flow, or template context is altered. Risk is negligible.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| corporate/views/remote_activity.py | Single-line style fix: replaced `dict(data=content, title=title, is_home=False)` with a dict literal `{"data": content, "title": title, "is_home": False}` to satisfy ruff C408. Functionally identical, no logic changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant get_remote_server_activity
    participant render

    Client->>get_remote_server_activity: HTTP GET request
    get_remote_server_activity->>render: request, "activity.html", context={"data": content, "title": title, "is_home": False}
    render-->>Client: HttpResponse (HTML)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandbox): ruff-c408 \[2942104e\]"](https://github.com/vikasagarwal101/zulip/commit/61070abe2d82e9ed57b6de676f71d22a0fd6251a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26258384)</sub>

<!-- /greptile_comment -->