### PR TITLE
fix(sandbox): ruff-c408 [corporate/views/support.py]

### DIFF
--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -936,7 +936,7 @@ def remote_servers_support(
         uuid_to_search=uuid_to_search,
         hostname_to_search=hostname_to_search,
     )
-    remote_server_to_max_monthly_messages: dict[int, int | str] = dict()
+    remote_server_to_max_monthly_messages: dict[int, int | str] = {}
     server_support_data: dict[int, RemoteSupportData] = {}
     realm_support_data: dict[int, RemoteSupportData] = {}
     remote_realms: dict[int, list[RemoteRealm]] = {}


### PR DESCRIPTION
## **User description**
Automated sandbox autofix PR.

[finding_id:b9a3017d99a2d8e273d97a0450689b0abf52b4ac42d37025c343c1b8d51a5e2c]
- dedupe_key: b9a3017d99a2d8e273d97a0450689b0abf52b4ac42d37025c343c1b8d51a5e2c
- rule: ruff-c408
- file: corporate/views/support.py:939
Fixes #55

___

## **CodeAnt-AI Description**
**Keep support page behavior unchanged while cleaning up setup**

### What Changed
- Support search results and filtering stay the same
- The support page now uses a simpler empty state for one internal data list

### Impact
`✅ Same support search results`
`✅ No change in support search behavior`
`✅ Lower risk of setup-related issues`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies the ruff C408 lint fix in `corporate/views/support.py`, replacing an unnecessary `dict()` constructor call with the equivalent empty-dict literal `{}` on line 939. The change is purely cosmetic/idiomatic — both forms produce an identical empty `dict[int, int | str]` at runtime — and fits naturally alongside the three adjacent dict-literal initializations already on lines 940–942.

- `remote_server_to_max_monthly_messages: dict[int, int | str] = dict()` → `= {}` (ruff C408 autofix)
- No behavioral, type-safety, or runtime impact whatsoever.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — trivial one-line style fix with zero behavioral impact.

The change is a single-line, semantically equivalent substitution (dict() → {}). No logic, data flow, or type signatures are altered. All remaining considerations are P2 or lower (none apply here), so the score is 5/5.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| corporate/views/support.py | Single-line idiomatic refactor: replaces `dict()` with `{}` for an empty dict literal (ruff C408). Functionally identical; type annotation is preserved. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["remote_servers_support()"] --> B["get_remote_servers_for_support()"]
    B --> C["remote_server_to_max_monthly_messages: dict[int, int | str] = {}\n(was dict() — ruff C408 fix)"]
    C --> D["server_support_data: dict[int, RemoteSupportData] = {}"]
    D --> E["realm_support_data: dict[int, RemoteSupportData] = {}"]
    E --> F["remote_realms: dict[int, list[RemoteRealm]] = {}"]
    F --> G["for remote_server in remote_servers: ..."]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandbox): ruff-c408 \[b9a3017d\]"](https://github.com/vikasagarwal101/zulip/commit/931e8837a57c7549e50b0c92ec4e817729df02e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26662262)</sub>

<!-- /greptile_comment -->