### PR TITLE
fix(sandbox): ruff-b904 [confirmation/models.py]

### DIFF
--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -108,8 +108,8 @@ def get_object_from_key(
         confirmation = Confirmation.objects.get(
             confirmation_key=confirmation_key, type__in=confirmation_types
         )
-    except Confirmation.DoesNotExist:
-        raise ConfirmationKeyError(ConfirmationKeyError.DOES_NOT_EXIST)
+    except Confirmation.DoesNotExist as e:
+        raise ConfirmationKeyError(ConfirmationKeyError.DOES_NOT_EXIST) from e
 
     if confirmation.expiry_date is not None and timezone_now() > confirmation.expiry_date:
         raise ConfirmationKeyError(ConfirmationKeyError.EXPIRED)


### PR DESCRIPTION
## **User description**
Automated sandbox autofix PR.

[finding_id:c8c2384283ac1e6104e065d8bb28d9e01598260876a68e1b2d1700a1ebdeeb82]
- dedupe_key: c8c2384283ac1e6104e065d8bb28d9e01598260876a68e1b2d1700a1ebdeeb82
- rule: ruff-b904
- file: confirmation/models.py:112
Fixes #66

___

## **CodeAnt-AI Description**
**Keep missing confirmation lookups tied to the original error**

### What Changed
- Looking up a confirmation that does not exist still returns the same “not found” result
- The failure now keeps the original error attached, which makes it easier to trace the cause when debugging

### Impact
`✅ Clearer confirmation lookup errors`
`✅ Easier debugging for missing keys`
`✅ No change to valid confirmation behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies a minimal, automated fix to `confirmation/models.py` to satisfy the [ruff B904](https://docs.astral.sh/ruff/rules/raise-without-from-cause/) lint rule — "Within an `except` clause, raise exceptions with `raise … from err`".

**Changes made:**
- In `get_object_from_key`, the caught `Confirmation.DoesNotExist` exception is now bound to `e` and passed as the cause via `raise ConfirmationKeyError(…) from e`.

**Impact:**
- The fix preserves the full exception chain, so if a `ConfirmationKeyError` is ever printed or logged, the original `Confirmation.DoesNotExist` traceback is visible as the `__cause__`, making debugging easier.
- No functional behaviour change — the same `ConfirmationKeyError(DOES_NOT_EXIST)` is raised in all the same circumstances.
- The rest of the file is untouched.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a correct, non-breaking linting fix with no functional changes.

The change is a single-line addition of exception chaining (`from e`), which is idiomatic Python and a strict improvement over the original. It introduces no new logic, alters no public APIs, and cannot break any callers since the same exception type is raised in the same situations.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| confirmation/models.py | Adds exception chaining (`from e`) when re-raising `ConfirmationKeyError` after catching `Confirmation.DoesNotExist`, satisfying the ruff B904 rule and preserving the original traceback. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[get_object_from_key called] --> B{Key length valid?}
    B -- No --> C[raise ConfirmationKeyError WRONG_LENGTH]
    B -- Yes --> D[Query Confirmation table]
    D -- Not Found --> E[catch DoesNotExist as e\nraise ConfirmationKeyError DOES_NOT_EXIST from e]
    D -- Found --> F{Expired?}
    F -- Yes --> G[raise ConfirmationKeyError EXPIRED]
    F -- No --> H{Status revoked/used?}
    H -- Yes --> I[raise ConfirmationKeyError EXPIRED]
    H -- No --> J[Return content object]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandbox): ruff-b904 \[c8c23842\]"](https://github.com/vikasagarwal101/zulip/commit/812b09432e7a15f2a5841ea822865005894239ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26999039)</sub>

<!-- /greptile_comment -->