### PR TITLE
fix(sandbox): ruff-b904 [corporate/lib/registration.py]

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -157,7 +157,7 @@ def get_chart_data_for_realm(
     try:
         realm = get_realm(realm_str)
     except Realm.DoesNotExist:
-        raise JsonableError(_("Invalid organization"))
+        raise JsonableError(_("Invalid organization")) from None
 
     return do_get_chart_data(
         request,

--- a/corporate/lib/billing_management.py
+++ b/corporate/lib/billing_management.py
@@ -53,7 +53,7 @@ class BillingSessionCommand(ZulipBaseCommand):
                     "There is no remote realm with uuid '{}'. Aborting.".format(
                         options["remote_realm_uuid"]
                     )
-                )
+                ) from None
         elif options["remote_server_uuid"]:
             remote_server_uuid = options["remote_server_uuid"]
             try:
@@ -64,7 +64,7 @@ class BillingSessionCommand(ZulipBaseCommand):
                     "There is no remote server with uuid '{}'. Aborting.".format(
                         options["remote_server_uuid"]
                     )
-                )
+                ) from None
 
         if realm is None and remote_realm is None and remote_server is None:
             raise CommandError(

--- a/corporate/lib/decorator.py
+++ b/corporate/lib/decorator.py
@@ -100,7 +100,7 @@ def authenticated_remote_realm_management_endpoint(
             if realm_uuid is None:
                 # This doesn't make sense - if get_remote_realm_and_user_from_session
                 # found an expired identity dict, it should have had a realm_uuid.
-                raise AssertionError
+                raise AssertionError from e
 
             assert server_uuid is not None, "identity_dict with realm_uuid must have server_uuid"
             assert uri_scheme is not None, "identity_dict with realm_uuid must have uri_scheme"
@@ -110,7 +110,7 @@ def authenticated_remote_realm_management_endpoint(
             except RemoteRealm.DoesNotExist:
                 # This should be impossible - unless the RemoteRealm existed and somehow the row
                 # was deleted.
-                raise AssertionError
+                raise AssertionError from None
 
             # Using EXTERNAL_URI_SCHEME means we'll do https:// in production, which is
             # the sane default - while having http:// in development, which will allow

--- a/corporate/lib/registration.py
+++ b/corporate/lib/registration.py
@@ -114,11 +114,11 @@ def check_spare_licenses_available_for_inviting_new_users(
 
     try:
         check_spare_licenses_available(realm, plan, extra_non_guests_count, extra_guests_count)
-    except LicenseLimitError:
+    except LicenseLimitError as e:
         message = _(
             "Your organization does not have enough Zulip licenses. Invitations were not sent."
         )
-        raise InvitationError(message, [], sent_invitations=False, license_limit_reached=True)
+        raise InvitationError(message, [], sent_invitations=False, license_limit_reached=True) from e
 
 
 def check_spare_license_available_for_changing_guest_user_role(realm: Realm) -> None:

--- a/corporate/lib/registration.py
+++ b/corporate/lib/registration.py
@@ -128,8 +128,8 @@ def check_spare_license_available_for_changing_guest_user_role(realm: Realm) -> 
 
     try:
         check_spare_licenses_available(realm, plan, extra_non_guests_count=1)
-    except LicenseLimitError:
+    except LicenseLimitError as e:
         error_message = _(
             "Your organization does not have enough Zulip licenses to change a guest user's role."
         )
-        raise JsonableError(error_message)
+        raise JsonableError(error_message) from e


### PR DESCRIPTION
## **User description**
Automated sandbox autofix PR.

[finding_id:80320ecd11c11579b96df8a0b92c04895174ced6d1fcaddea3ed53235d41c683]
- dedupe_key: 80320ecd11c11579b96df8a0b92c04895174ced6d1fcaddea3ed53235d41c683
- rule: ruff-b904
- file: corporate/lib/registration.py:121
Fixes #72

___

## **CodeAnt-AI Description**
**Make license, billing, and analytics errors show clean messages**

### What Changed
- Errors for missing or invalid organizations now return a simple message without extra internal exception details
- Billing commands for unknown remote realms and remote servers now fail with a clearer command error
- License-limit errors keep the same user-facing text, but no longer include unrelated traceback context

### Impact
`✅ Clearer invalid organization errors`
`✅ Cleaner billing failure messages`
`✅ Less noisy license limit errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes ruff B904 linting violations across four files by explicitly specifying exception chaining behavior (`from e` or `from None`) when re-raising exceptions inside `except` blocks. All changes are mechanically correct and improve exception transparency without affecting runtime behavior.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are mechanical linting fixes with no behavioral impact.

All four files receive straightforward ruff B904 fixes. The `from e` / `from None` choices are semantically appropriate in each context, and no logic, data flow, or security boundaries are altered.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The changes only add explicit exception chaining (`from e` / `from None`) and do not affect authentication logic, data handling, or user-facing error content.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| corporate/lib/registration.py | Correctly adds `from e` to two re-raises, chaining LicenseLimitError context into InvitationError and JsonableError. |
| analytics/views/stats.py | Adds `from None` to suppress Realm.DoesNotExist context when raising a user-facing JsonableError — appropriate choice. |
| corporate/lib/billing_management.py | Adds `from None` to two CommandError raises in management command, suppressing internal DoesNotExist context — appropriate for CLI error messages. |
| corporate/lib/decorator.py | Adds `from e` to chain AssertionError to the expired-identity error (helpful for debugging), and `from None` to suppress the impossible DoesNotExist case — both choices are reasonable. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[except block catches original exception] --> B{Re-raise as different type?}
    B -->|Preserve context for debugging| C["raise NewError from e\n(chains original exception)"]
    B -->|Suppress internal details| D["raise NewError from None\n(clean traceback)"]
    C --> E["registration.py: LicenseLimitError → InvitationError/JsonableError\ndecorator.py: expired identity → AssertionError"]
    D --> F["stats.py: DoesNotExist → JsonableError\nbilling_management.py: DoesNotExist → CommandError\ndecorator.py: impossible DoesNotExist → AssertionError"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandbox): ruff-b904 \[80320ecd\]"](https://github.com/vikasagarwal101/zulip/commit/feeb30ac444ffefa137deffd486270eefb40cc65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27718573)</sub>

<!-- /greptile_comment -->