### PR TITLE
fix(sandbox): ruff-b904 [corporate/lib/registration.py]

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -157,7 +157,7 @@ def get_chart_data_for_realm(
     try:
         realm = get_realm(realm_str)
     except Realm.DoesNotExist:
-        raise JsonableError(_("Invalid organization"))
+        raise JsonableError(_("Invalid organization")) from None
 
     return do_get_chart_data(
         request,

--- a/corporate/lib/billing_management.py
+++ b/corporate/lib/billing_management.py
@@ -53,7 +53,7 @@ class BillingSessionCommand(ZulipBaseCommand):
                     "There is no remote realm with uuid '{}'. Aborting.".format(
                         options["remote_realm_uuid"]
                     )
-                )
+                ) from None
         elif options["remote_server_uuid"]:
             remote_server_uuid = options["remote_server_uuid"]
             try:
@@ -64,7 +64,7 @@ class BillingSessionCommand(ZulipBaseCommand):
                     "There is no remote server with uuid '{}'. Aborting.".format(
                         options["remote_server_uuid"]
                     )
-                )
+                ) from None
 
         if realm is None and remote_realm is None and remote_server is None:
             raise CommandError(

--- a/corporate/lib/decorator.py
+++ b/corporate/lib/decorator.py
@@ -100,7 +100,7 @@ def authenticated_remote_realm_management_endpoint(
             if realm_uuid is None:
                 # This doesn't make sense - if get_remote_realm_and_user_from_session
                 # found an expired identity dict, it should have had a realm_uuid.
-                raise AssertionError
+                raise AssertionError from e
 
             assert server_uuid is not None, "identity_dict with realm_uuid must have server_uuid"
             assert uri_scheme is not None, "identity_dict with realm_uuid must have uri_scheme"
@@ -110,7 +110,7 @@ def authenticated_remote_realm_management_endpoint(
             except RemoteRealm.DoesNotExist:
                 # This should be impossible - unless the RemoteRealm existed and somehow the row
                 # was deleted.
-                raise AssertionError
+                raise AssertionError from None
 
             # Using EXTERNAL_URI_SCHEME means we'll do https:// in production, which is
             # the sane default - while having http:// in development, which will allow

--- a/corporate/lib/registration.py
+++ b/corporate/lib/registration.py
@@ -114,11 +114,11 @@ def check_spare_licenses_available_for_inviting_new_users(
 
     try:
         check_spare_licenses_available(realm, plan, extra_non_guests_count, extra_guests_count)
-    except LicenseLimitError:
+    except LicenseLimitError as e:
         message = _(
             "Your organization does not have enough Zulip licenses. Invitations were not sent."
         )
-        raise InvitationError(message, [], sent_invitations=False, license_limit_reached=True)
+        raise InvitationError(message, [], sent_invitations=False, license_limit_reached=True) from e
 
 
 def check_spare_license_available_for_changing_guest_user_role(realm: Realm) -> None:

--- a/corporate/lib/registration.py
+++ b/corporate/lib/registration.py
@@ -128,8 +128,8 @@ def check_spare_license_available_for_changing_guest_user_role(realm: Realm) -> 
 
     try:
         check_spare_licenses_available(realm, plan, extra_non_guests_count=1)
-    except LicenseLimitError:
+    except LicenseLimitError as e:
         error_message = _(
             "Your organization does not have enough Zulip licenses to change a guest user's role."
         )
-        raise JsonableError(error_message)
+        raise JsonableError(error_message) from e


### PR DESCRIPTION
## **User description**
Automated sandbox autofix PR.

[finding_id:3d6f18fe2455160e15d86bf94cb1017e86b646549778d80eff3dee7fe1d4197d]
- dedupe_key: 3d6f18fe2455160e15d86bf94cb1017e86b646549778d80eff3dee7fe1d4197d
- rule: ruff-b904
- file: corporate/lib/registration.py:135
Fixes #73

___

## **CodeAnt-AI Description**
**Clearer errors when billing or organization lookups fail**

### What Changed
- Missing or invalid organizations now return a plain “Invalid organization” error without extra error context
- Missing remote billing entities now raise a direct “not found” error instead of exposing unrelated lookup details
- License-limit failures keep the original cause attached while showing the same user-facing message for invitation and role-change actions

### Impact
`✅ Clearer organization error messages`
`✅ Less confusing billing lookup failures`
`✅ Cleaner license-limit errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies automated ruff B904 fixes across four files, adding explicit exception chaining (`from e` or `from None`) to `raise` statements inside `except` blocks. The changes are largely correct but use `from None` (suppressing chain) in some places and `from e` (preserving chain) in others.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are mechanical B904 lint fixes with correct semantics.

All four files receive straightforward exception-chaining fixes. The choice of `from e` vs `from None` in each location is appropriate given the context (user-facing vs internal errors, availability of a meaningful cause exception). No logic, data flow, or security concerns were introduced.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Using `from None` to suppress internal exception details (e.g., `DoesNotExist`) in user-facing errors is actually a minor positive — it avoids leaking internal implementation details in tracebacks.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| corporate/lib/registration.py | Catches LicenseLimitError as `e` and chains it to InvitationError/JsonableError via `from e` — correct and preserves debugging context. |
| corporate/lib/decorator.py | Two AssertionError raises: one now chains to the outer expired-session exception (`from e`), the other explicitly suppresses with `from None` — both semantically appropriate given the surrounding comments. |
| analytics/views/stats.py | JsonableError raised with `from None` to suppress Realm.DoesNotExist — appropriate for a user-facing API error. |
| corporate/lib/billing_management.py | Two CommandError raises now use `from None` — acceptable for management commands where the original DoesNotExist is an implementation detail. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[except block catches exception] --> B{Is original context useful?}
    B -- Yes --> C["raise NewException from e\n(chains original exception)"]
    B -- No --> D["raise NewException from None\n(suppresses original exception)"]
    C --> E[registration.py: LicenseLimitError → InvitationError/JsonableError]
    C --> F[decorator.py L103: ExpiredSession → AssertionError]
    D --> G[analytics/stats.py: DoesNotExist → JsonableError]
    D --> H[billing_management.py: DoesNotExist → CommandError]
    D --> I[decorator.py L113: DoesNotExist → AssertionError]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandbox): ruff-b904 \[3d6f18fe\]"](https://github.com/vikasagarwal101/zulip/commit/9a43797647b09959c13e875ae727d42f62b169f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27719851)</sub>

<!-- /greptile_comment -->