### PR TITLE
fix(sandbox): ruff-b904 [corporate/management/commands/initialize_fixed_price_plan.py]

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -157,7 +157,7 @@ def get_chart_data_for_realm(
     try:
         realm = get_realm(realm_str)
     except Realm.DoesNotExist:
-        raise JsonableError(_("Invalid organization"))
+        raise JsonableError(_("Invalid organization")) from None
 
     return do_get_chart_data(
         request,

--- a/corporate/lib/billing_management.py
+++ b/corporate/lib/billing_management.py
@@ -53,7 +53,7 @@ class BillingSessionCommand(ZulipBaseCommand):
                     "There is no remote realm with uuid '{}'. Aborting.".format(
                         options["remote_realm_uuid"]
                     )
-                )
+                ) from None
         elif options["remote_server_uuid"]:
             remote_server_uuid = options["remote_server_uuid"]
             try:
@@ -64,7 +64,7 @@ class BillingSessionCommand(ZulipBaseCommand):
                     "There is no remote server with uuid '{}'. Aborting.".format(
                         options["remote_server_uuid"]
                     )
-                )
+                ) from None
 
         if realm is None and remote_realm is None and remote_server is None:
             raise CommandError(

--- a/corporate/lib/decorator.py
+++ b/corporate/lib/decorator.py
@@ -100,7 +100,7 @@ def authenticated_remote_realm_management_endpoint(
             if realm_uuid is None:
                 # This doesn't make sense - if get_remote_realm_and_user_from_session
                 # found an expired identity dict, it should have had a realm_uuid.
-                raise AssertionError
+                raise AssertionError from e
 
             assert server_uuid is not None, "identity_dict with realm_uuid must have server_uuid"
             assert uri_scheme is not None, "identity_dict with realm_uuid must have uri_scheme"
@@ -110,7 +110,7 @@ def authenticated_remote_realm_management_endpoint(
             except RemoteRealm.DoesNotExist:
                 # This should be impossible - unless the RemoteRealm existed and somehow the row
                 # was deleted.
-                raise AssertionError
+                raise AssertionError from None
 
             # Using EXTERNAL_URI_SCHEME means we'll do https:// in production, which is
             # the sane default - while having http:// in development, which will allow

--- a/corporate/lib/registration.py
+++ b/corporate/lib/registration.py
@@ -114,11 +114,11 @@ def check_spare_licenses_available_for_inviting_new_users(
 
     try:
         check_spare_licenses_available(realm, plan, extra_non_guests_count, extra_guests_count)
-    except LicenseLimitError:
+    except LicenseLimitError as e:
         message = _(
             "Your organization does not have enough Zulip licenses. Invitations were not sent."
         )
-        raise InvitationError(message, [], sent_invitations=False, license_limit_reached=True)
+        raise InvitationError(message, [], sent_invitations=False, license_limit_reached=True) from e
 
 
 def check_spare_license_available_for_changing_guest_user_role(realm: Realm) -> None:

--- a/corporate/management/commands/initialize_fixed_price_plan.py
+++ b/corporate/management/commands/initialize_fixed_price_plan.py
@@ -75,14 +75,14 @@ class Command(BillingSessionCommand):
                 )
                 return
             except BillingError as e:
-                raise CommandError(e.msg)
+                raise CommandError(e.msg) from e
             except AssertionError as e:
-                raise CommandError(e)
+                raise CommandError(e) from e
         else:
             try:
                 billing_session.initialize_prepaid_fixed_price_plan(plan_tier, billing_cycle_anchor)
                 print("Done! Check support panel for customer to review active fixed-price plan.")
             except BillingError as e:
-                raise CommandError(e.msg)
+                raise CommandError(e.msg) from e
             except AssertionError as e:
-                raise CommandError(e)
+                raise CommandError(e) from e


### PR DESCRIPTION
## **User description**
Automated sandbox autofix PR.

[finding_id:3aecb307c612ba2f5f0831a75e8d3b678f9403a8388c941c28e4c1fe058bd553]
- dedupe_key: 3aecb307c612ba2f5f0831a75e8d3b678f9403a8388c941c28e4c1fe058bd553
- rule: ruff-b904
- file: corporate/management/commands/initialize_fixed_price_plan.py:78
Fixes #25

___

## **CodeAnt-AI Description**
**Hide internal exception details in billing and analytics errors**

### What Changed
- Invalid organization lookups now return a simple error without exposing the underlying lookup failure
- Billing and licensing command errors now keep the original cause attached when available, while missing realms and servers still show clear “not found” messages
- A billing redirect check now preserves the original failure context when an expected internal condition is missing

### Impact
`✅ Clearer invalid organization errors`
`✅ Cleaner billing command failures`
`✅ Less confusing admin error reports`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This automated sandbox PR fixes ruff B904 violations across five files by adding explicit `from e` or `from None` exception chaining to `raise` statements inside `except` blocks. Most changes are correct: `corporate/lib/registration.py` and `corporate/management/commands/initialize_fixed_price_plan.py` use `from e` to preserve context, while `analytics/views/stats.py` and `corporate/lib/billing_management.py` use `from None` for user-facing error conversions where suppressing the chain is acceptable. One minor inconsistency exists in `corporate/lib/decorator.py`, where the `RemoteRealm.DoesNotExist` branch uses `from None` while the adjacent `SessionExpiredError` branch uses `from e`, discarding debug context in an \"impossible\" error path.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes satisfy ruff B904 with no functional impact.

All findings are P2 style suggestions. The sole notable point — using `from None` instead of `from e` in one branch of `decorator.py` — loses some debug context but introduces no incorrect behavior. No logic, data handling, or security boundaries are affected.

corporate/lib/decorator.py — minor inconsistency in exception chaining between the two AssertionError raises.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The changes only affect exception chaining syntax (`from e` / `from None`) and introduce no new code paths, data handling, or access control logic.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| analytics/views/stats.py | Adds `from None` to suppress the `Realm.DoesNotExist` chain when raising `JsonableError`; satisfies ruff B904 and is reasonable for a user-facing API error. |
| corporate/lib/billing_management.py | Adds `from None` to two `CommandError` raises in management-command except blocks; satisfies B904 and is appropriate for user-facing error messages. |
| corporate/lib/decorator.py | Two `AssertionError` raises use inconsistent chaining: the SessionExpiredError branch uses `from e` (preserving context) while the RemoteRealm.DoesNotExist branch uses `from None` (discarding it), losing debug value in an "impossible" scenario. |
| corporate/lib/registration.py | Correctly chains `LicenseLimitError` into `InvitationError` using `from e`, preserving the full exception context. |
| corporate/management/commands/initialize_fixed_price_plan.py | Correctly chains all four `CommandError` raises with `from e`, preserving `BillingError` and `AssertionError` context for debugging. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ruff B904 violation\nexcept block raises without chaining] --> B{Which pattern?}
    B -->|Preserve context| C["raise NewError(...) from e"]
    B -->|Suppress chain| D["raise NewError(...) from None"]

    C --> E[registration.py\nLicenseLimitError → InvitationError]
    C --> F[initialize_fixed_price_plan.py\nBillingError/AssertionError → CommandError]
    C --> G[decorator.py line 103\nSessionExpiredError → AssertionError]

    D --> H[analytics/views/stats.py\nRealm.DoesNotExist → JsonableError]
    D --> I[billing_management.py\nDoesNotExist → CommandError]
    D --> J["decorator.py line 113\nRemoteRealm.DoesNotExist → AssertionError\n⚠️ inconsistent with line 103"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandbox): ruff-b904 \[3aecb307\]"](https://github.com/vikasagarwal101/zulip/commit/3c44e5f02785d5079fb6e2ce752a1a1099a4a779) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27727662)</sub>

<!-- /greptile_comment -->