### PR TITLE
fix: resolve 2 ruff-s311 findings

### DIFF
--- a/analytics/lib/fixtures.py
+++ b/analytics/lib/fixtures.py
@@ -35,7 +35,7 @@ def generate_time_series_data(
     partial_sum -- If True, return partial sum of the series.
     random_seed -- Seed for random number generator.
     """
-    rng = Random(random_seed)
+    rng = Random(random_seed)  # noqa: S311
 
     if frequency == CountStat.HOUR:
         length = days * 24

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -8,7 +8,7 @@ import logging
 import os
 import platform
 import pwd
-import random
+import secrets
 import shlex
 import shutil
 import signal
@@ -51,7 +51,7 @@ def overwrite_symlink(src: str, dst: str) -> None:
         # Note: creating a temporary filename like this is not generally
         # secure.  It’s fine in this case because os.symlink refuses to
         # overwrite an existing target; we handle the error and try again.
-        tmp = os.path.join(dir, f".{base}.{random.randrange(1 << 40):010x}")
+        tmp = os.path.join(dir, f".{base}.{secrets.randbits(40):010x}")
         try:
             os.symlink(src, tmp)
         except FileExistsError:


### PR DESCRIPTION
## **User description**
## Batch Fix: 2 ruff-s311 findings

This PR resolves 2 findings of type `ruff-s311` across 2 files.

### Findings

| # | File | Line | Issue |
|---|------|------|-------|
| 1 | `analytics/lib/fixtures.py` | 38 | [#76](...) |
| 2 | `scripts/lib/zulip_tools.py` | 54 | unlinked |

### Scope
- Files changed: 2
- Fix method: autofix

### Verification
- [ ] All target detectors no longer fire
- [ ] No baseline regressions

---
*Generated by qa-agent batch PR engine*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses two `ruff-S311` findings (use of non-cryptographic random generators) via two different approaches: a proper substitution of `secrets.randbits` in `scripts/lib/zulip_tools.py`, and an intentional suppression comment in `analytics/lib/fixtures.py` where the seeded `Random` is by design.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both S311 fixes are correct and functionally equivalent to the original code.

The secrets.randbits(40) substitution is a drop-in replacement for random.randrange(1 << 40) with the same range; no remaining random usages were left behind. The noqa suppression in fixtures.py is justified by the function's explicit seeding contract. No logic, security, or correctness issues were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| analytics/lib/fixtures.py | Adds `# noqa: S311` to the seeded `Random(random_seed)` call; suppression is appropriate since reproducibility is the explicit design goal of this fixture helper. |
| scripts/lib/zulip_tools.py | Replaces `import random` / `random.randrange(1 << 40)` with `import secrets` / `secrets.randbits(40)`; equivalent range [0, 2⁴⁰), no remaining usages of `random` in the file. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[S311 Finding] --> B{Context}
    B -- "Seeded RNG for reproducible\ntest fixture data" --> C["analytics/lib/fixtures.py\n→ keep Random, add # noqa: S311"]
    B -- "Temp filename suffix\n(security-sensitive)" --> D["scripts/lib/zulip_tools.py\n→ replace random with secrets"]
    C --> E[Suppression: intentional, deterministic RNG]
    D --> F[Fix: cryptographically secure randbits 40]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve 2 ruff-s311 findings"](https://github.com/vikasagarwal101/zulip/commit/f4347395a09c8f98f34becf053a9e0a0e345cf33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29758667)</sub>

<!-- /greptile_comment -->


___

## **CodeAnt-AI Description**
**Use safer random values for temporary filenames and keep seeded test data as intended**

### What Changed
- Temporary filenames now use a safer random source before creating symlinks
- The seeded random generator used for fixture data is kept, with an explicit note that this is intentional for repeatable test data

### Impact
`✅ Safer temporary file naming`
`✅ Fewer security warnings in utility scripts`
`✅ Stable repeatable test fixtures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=7gji0lZaiv665aOvQBuwdXTqmG-gL-64Ea0IONsvWuM&org=vikasagarwal101)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
