### PR TITLE
fix: resolve 2 ruff-s311 findings

### DIFF
--- a/analytics/lib/fixtures.py
+++ b/analytics/lib/fixtures.py
@@ -35,7 +35,7 @@ def generate_time_series_data(
     partial_sum -- If True, return partial sum of the series.
     random_seed -- Seed for random number generator.
     """
-    rng = Random(random_seed)
+    rng = Random(random_seed)  # noqa: S311
 
     if frequency == CountStat.HOUR:
         length = days * 24

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -8,7 +8,7 @@ import logging
 import os
 import platform
 import pwd
-import random
+import secrets
 import shlex
 import shutil
 import signal
@@ -51,7 +51,7 @@ def overwrite_symlink(src: str, dst: str) -> None:
         # Note: creating a temporary filename like this is not generally
         # secure.  It’s fine in this case because os.symlink refuses to
         # overwrite an existing target; we handle the error and try again.
-        tmp = os.path.join(dir, f".{base}.{random.randrange(1 << 40):010x}")
+        tmp = os.path.join(dir, f".{base}.{secrets.randbits(40):010x}")
         try:
             os.symlink(src, tmp)
         except FileExistsError:


### PR DESCRIPTION
## **User description**
## Batch Fix: 2 ruff-s311 findings

This PR resolves 2 findings of type `ruff-s311` across 2 files.

### Findings

| # | File | Line | Issue |
|---|------|------|-------|
| 1 | `analytics/lib/fixtures.py` | 38 | [#76](...) |
| 2 | `scripts/lib/zulip_tools.py` | 54 | unlinked |

### Scope
- Files changed: 2
- Fix method: autofix

### Verification
- [ ] All target detectors no longer fire
- [ ] No baseline regressions

---
*Generated by qa-agent batch PR engine*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR resolves two `ruff-s311` findings across two files. In `analytics/lib/fixtures.py`, the warning is suppressed with `# noqa: S311` — the correct approach since `Random` is intentionally seeded for deterministic test fixture generation (not a security context). In `scripts/lib/zulip_tools.py`, `random.randrange(1 << 40)` is replaced with `secrets.randbits(40)`, a semantically equivalent operation using a CSPRNG, which is the right fix for a temporary filename context.
</details>

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — both fixes are minimal, correct, and do not change observable behavior.

Both changes are straightforward and appropriate: the noqa suppression in fixtures.py preserves deterministic seeded randomness for tests, and the secrets.randbits(40) substitution in zulip_tools.py is range-equivalent to the original random.randrange call while using a CSPRNG as intended. No regressions or side effects are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| analytics/lib/fixtures.py | Adds `# noqa: S311` suppression on line 38 — appropriate since `Random` is seeded for reproducible test fixture generation, not security. |
| scripts/lib/zulip_tools.py | Replaces `random.randrange(1 << 40)` with `secrets.randbits(40)` for temporary filename generation — semantically equivalent range, proper fix using a CSPRNG. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[S311 Findings] --> B{Context?}
    B -->|Seeded, reproducible test data| C["analytics/lib/fixtures.py\nRandom(seed) — suppress with # noqa: S311"]
    B -->|Temp filename generation| D["scripts/lib/zulip_tools.py\nreplace random.randrange → secrets.randbits(40)"]
    C --> E[Deterministic fixture output preserved]
    D --> F[Cryptographically secure random temp name]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve 2 ruff-s311 findings"](https://github.com/vikasagarwal101/zulip/commit/9c75bbaffbda2c97baf0559076af2c0876be7c40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29807492)</sub>

<!-- /greptile_comment -->


___

## **CodeAnt-AI Description**
**Fix two security lint findings without changing behavior**

### What Changed
- Marked the seeded random generator used for test data as an intentional exception, so it no longer triggers the security warning
- Switched temporary symlink name generation to a secure random source while keeping the same overwrite behavior

### Impact
`✅ Fewer security lint warnings`
`✅ Safer temporary filename generation`
`✅ No change to test data output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=AphBLS_PITQaPb-rjI_A3tRwZOb3Om9fpl0PCj35eWY&org=vikasagarwal101)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
