### PR TITLE
fix: resolve 9 ruff-c408 findings

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -80,22 +80,22 @@ def render_stats(
     )
 
     # Sync this with stats_params_schema in base_page_params.ts.
-    page_params = dict(
-        page_type="stats",
-        data_url_suffix=data_url_suffix,
-        upload_space_used=space_used,
-        guest_users=guest_users,
-        translation_data=get_language_translation_data(request_language),
-    )
+    page_params = {
+        "page_type": "stats",
+        "data_url_suffix": data_url_suffix,
+        "upload_space_used": space_used,
+        "guest_users": guest_users,
+        "translation_data": get_language_translation_data(request_language),
+    }
 
     return render(
         request,
         "analytics/stats.html",
-        context=dict(
-            target_name=title,
-            page_params=page_params,
-            analytics_ready=analytics_ready,
-        ),
+        context={
+            "target_name": title,
+            "page_params": page_params,
+            "analytics_ready": analytics_ready,
+        },
     )
 
 

--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -55,17 +55,17 @@ def make_table(
     if not has_row_class:
 
         def fix_row(row: Any) -> dict[str, Any]:
-            return dict(cells=row, row_class=None)
+            return {"cells": row, "row_class": None}
 
         rows = list(map(fix_row, rows))
 
-    data = dict(
-        title=title, cols=cols, rows=rows, header=header, totals=totals, title_link=title_link
-    )
+    data = {
+        "title": title, "cols": cols, "rows": rows, "header": header, "totals": totals, "title_link": title_link
+    }
 
     content = loader.render_to_string(
         "corporate/activity/activity_table.html",
-        dict(data=data),
+        {"data": data},
     )
 
     return content
@@ -118,7 +118,7 @@ def format_none_as_zero(value: int | None) -> int:
 def user_activity_link(link_text: str, user_profile_id: int) -> Markup:
     from corporate.views.user_activity import get_user_activity
 
-    url = reverse(get_user_activity, kwargs=dict(user_profile_id=user_profile_id))
+    url = reverse(get_user_activity, kwargs={user_profile_id: user_profile_id})
     if link_text == "":
         return Markup('<a href="{url}"><i class="fa fa-user-circle"></i></a>').format(url=url)
     return Markup('<a href="{url}">{link_text}</a>').format(url=url, link_text=link_text)
@@ -127,14 +127,14 @@ def user_activity_link(link_text: str, user_profile_id: int) -> Markup:
 def realm_activity_link(realm_str: str) -> Markup:
     from corporate.views.realm_activity import get_realm_activity
 
-    url = reverse(get_realm_activity, kwargs=dict(realm_str=realm_str))
+    url = reverse(get_realm_activity, kwargs={"realm_str": realm_str})
     return Markup('<a href="{url}"><i class="fa fa-table"></i></a>').format(url=url)
 
 
 def realm_stats_link(realm_str: str) -> Markup:
     from analytics.views.stats import stats_for_realm
 
-    url = reverse(stats_for_realm, kwargs=dict(realm_str=realm_str))
+    url = reverse(stats_for_realm, kwargs={"realm_str": realm_str})
     return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a>').format(url=url)
 
 
@@ -157,7 +157,7 @@ def realm_url_link(realm_str: str) -> Markup:
 def remote_installation_stats_link(server_id: int) -> Markup:
     from analytics.views.stats import stats_for_remote_installation
 
-    url = reverse(stats_for_remote_installation, kwargs=dict(remote_server_id=server_id))
+    url = reverse(stats_for_remote_installation, kwargs={"remote_server_id": server_id})
     return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a>').format(url=url)
 
 


### PR DESCRIPTION
## **User description**
## Batch Fix: 9 ruff-c408 findings

This PR resolves 9 findings of type `ruff-c408` across 2 files.

### Findings

| # | File | Line | Issue |
|---|------|------|-------|
| 1 | `analytics/views/stats.py` | 83 | [#89](...) |
| 2 | `analytics/views/stats.py` | 94 | [#90](...) |
| 3 | `corporate/lib/activity.py` | 58 | [#93](...) |
| 4 | `corporate/lib/activity.py` | 62 | [#94](...) |
| 5 | `corporate/lib/activity.py` | 68 | [#95](...) |
| 6 | `corporate/lib/activity.py` | 121 | [#96](...) |
| 7 | `corporate/lib/activity.py` | 130 | [#97](...) |
| 8 | `corporate/lib/activity.py` | 137 | [#98](...) |
| 9 | `corporate/lib/activity.py` | 160 | [#99](...) |

### Scope
- Files changed: 2
- Fix method: autofix

### Verification
- [ ] All target detectors no longer fire
- [ ] No baseline regressions

---
*Generated by qa-agent batch PR engine*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR converts 9 `dict(...)` constructor calls to dict literal syntax (`{...}`) across `analytics/views/stats.py` and `corporate/lib/activity.py` to satisfy the `ruff-c408` linter rule. Eight of the nine conversions are correct, but one autofix in `corporate/lib/activity.py` introduces a runtime-breaking bug.

- **P0 — `corporate/lib/activity.py` line 121**: `dict(user_profile_id=user_profile_id)` was incorrectly converted to `{user_profile_id: user_profile_id}`, using the integer variable as the dict key instead of the string `\"user_profile_id\"`. Django's `reverse()` requires string keys in `kwargs`, so every call to `user_activity_link()` will raise a `NoReverseMatch` exception until this is fixed to `{\"user_profile_id\": user_profile_id}`.
</details>

<h3>Confidence Score: 1/5</h3>

Not safe to merge — contains a runtime-breaking bug that will crash every call to user_activity_link.

A single P0 bug was introduced by the autofix: using an integer variable as a dict key instead of a string literal causes Django's reverse() to raise NoReverseMatch on every invocation of user_activity_link. This is a definite runtime failure on a changed code path.

corporate/lib/activity.py line 121 — integer variable used as dict key in kwargs passed to Django reverse().

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| analytics/views/stats.py | Two dict(...) calls correctly converted to dict literals with string keys — no issues. |
| corporate/lib/activity.py | Seven dict(...) conversions, six correct; one critical bug on line 121 where dict(user_profile_id=user_profile_id) was wrongly converted to {user_profile_id: user_profile_id} (integer key instead of string key), breaking Django URL reversal. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["user_activity_link(link_text, user_profile_id)"] --> B["reverse(get_user_activity, kwargs={user_profile_id: user_profile_id})"]
    B --> C{"kwargs key type?"}
    C -- "integer key (current bug)" --> D["❌ NoReverseMatch — Django expects string keys"]
    C -- "string key (correct fix)" --> E["✅ URL resolved successfully"]
    E --> F["Return Markup HTML link"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve 9 ruff-c408 findings"](https://github.com/vikasagarwal101/zulip/commit/1e2c7e96f80a4976216b150835df98044e51f559) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30545918)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->


___

## **CodeAnt-AI Description**
**Fix broken activity and stats links**

### What Changed
- User, realm, remote-installation, and stats links now open with the correct page parameters
- Activity tables and stats pages still render the same content, but use simpler data setup behind the scenes
- Fixed a bad user activity link that could fail to open the user’s activity page

### Impact
`✅ Fewer broken activity links`
`✅ Clearer user and realm navigation`
`✅ More reliable stats page links`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=xpgMApOthjaA0NfytFJ2zRACFGVFpswCvZhX9zfQJdw&org=vikasagarwal101)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
