### PR TITLE
fix: resolve 9 ruff-c408 findings

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -80,22 +80,22 @@ def render_stats(
     )
 
     # Sync this with stats_params_schema in base_page_params.ts.
-    page_params = dict(
-        page_type="stats",
-        data_url_suffix=data_url_suffix,
-        upload_space_used=space_used,
-        guest_users=guest_users,
-        translation_data=get_language_translation_data(request_language),
-    )
+    page_params = {
+        "page_type": "stats",
+        "data_url_suffix": data_url_suffix,
+        "upload_space_used": space_used,
+        "guest_users": guest_users,
+        "translation_data": get_language_translation_data(request_language),
+    }
 
     return render(
         request,
         "analytics/stats.html",
-        context=dict(
-            target_name=title,
-            page_params=page_params,
-            analytics_ready=analytics_ready,
-        ),
+        {
+            "target_name": title,
+            "page_params": page_params,
+            "analytics_ready": analytics_ready,
+        },
     )
 
 

--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -55,17 +55,17 @@ def make_table(
     if not has_row_class:
 
         def fix_row(row: Any) -> dict[str, Any]:
-            return dict(cells=row, row_class=None)
+            return {"cells": row, "row_class": None}
 
         rows = list(map(fix_row, rows))
 
-    data = dict(
-        title=title, cols=cols, rows=rows, header=header, totals=totals, title_link=title_link
-    )
+    data = {
+        title: title, cols: cols, rows: rows, header: header, totals: totals, title_link: title_link
+    }
 
     content = loader.render_to_string(
         "corporate/activity/activity_table.html",
-        dict(data=data),
+        data,
     )
 
     return content
@@ -118,7 +118,7 @@ def format_none_as_zero(value: int | None) -> int:
 def user_activity_link(link_text: str, user_profile_id: int) -> Markup:
     from corporate.views.user_activity import get_user_activity
 
-    url = reverse(get_user_activity, kwargs=dict(user_profile_id=user_profile_id))
+    url = reverse(get_user_activity, kwargs={"user_profile_id": user_profile_id})
     if link_text == "":
         return Markup('<a href="{url}"><i class="fa fa-user-circle"></i></a>').format(url=url)
     return Markup('<a href="{url}">{link_text}</a>').format(url=url, link_text=link_text)
@@ -127,14 +127,14 @@ def user_activity_link(link_text: str, user_profile_id: int) -> Markup:
 def realm_activity_link(realm_str: str) -> Markup:
     from corporate.views.realm_activity import get_realm_activity
 
-    url = reverse(get_realm_activity, kwargs=dict(realm_str=realm_str))
+    url = reverse(get_realm_activity, kwargs={"realm_str": realm_str})
     return Markup('<a href="{url}"><i class="fa fa-table"></i></a>').format(url=url)
 
 
 def realm_stats_link(realm_str: str) -> Markup:
     from analytics.views.stats import stats_for_realm
 
-    url = reverse(stats_for_realm, kwargs=dict(realm_str=realm_str))
+    url = reverse(stats_for_realm, kwargs={"realm_str": realm_str})
     return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a>').format(url=url)
 
 
@@ -157,7 +157,7 @@ def realm_url_link(realm_str: str) -> Markup:
 def remote_installation_stats_link(server_id: int) -> Markup:
     from analytics.views.stats import stats_for_remote_installation
 
-    url = reverse(stats_for_remote_installation, kwargs=dict(remote_server_id=server_id))
+    url = reverse(stats_for_remote_installation, kwargs={"remote_server_id": server_id})
     return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a>').format(url=url)
 
 


### PR DESCRIPTION
## **User description**
## Batch Fix: 9 ruff-c408 findings

This PR resolves 9 findings of type `ruff-c408` across 2 files.

### Findings

| # | File | Line | Issue |
|---|------|------|-------|
| 1 | `analytics/views/stats.py` | 83 | [#89](...) |
| 2 | `analytics/views/stats.py` | 94 | [#90](...) |
| 3 | `corporate/lib/activity.py` | 58 | [#93](...) |
| 4 | `corporate/lib/activity.py` | 62 | [#94](...) |
| 5 | `corporate/lib/activity.py` | 68 | [#95](...) |
| 6 | `corporate/lib/activity.py` | 121 | [#96](...) |
| 7 | `corporate/lib/activity.py` | 130 | [#97](...) |
| 8 | `corporate/lib/activity.py` | 137 | [#98](...) |
| 9 | `corporate/lib/activity.py` | 160 | [#99](...) |

### Scope
- Files changed: 2
- Fix method: autofix

### Verification
- [ ] All target detectors no longer fire
- [ ] No baseline regressions

---
*Generated by qa-agent batch PR engine*

___

## **CodeAnt-AI Description**
**Clean up internal data passing in stats and activity pages**

### What Changed
- Kept the same stats and activity pages, but simplified how page data and link details are assembled
- No user-facing text, layout, or navigation changes are introduced

### Impact
`✅ No visible change for users`
`✅ Safer maintenance of stats and activity pages`
`✅ Fewer style-rule violations`

[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=PCaAJxMZaOqKaSB3_KzUgTOreaL6llbbBfPztCbobdY&org=vikasagarwal101)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies automated C408 fixes across two files, but the autofix in `corporate/lib/activity.py` introduces two P0 regressions in `make_table`.

- The dict literal `{title: title, cols: cols, ...}` uses variable references as keys instead of string literals (`\"title\"`, `\"cols\"`, …), producing a malformed context dict at runtime.
- The `render_to_string` call was also changed from `{\"data\": data}` to bare `data`, breaking the template's expected `{{ data.* }}` variable namespace.
</details>

<h3>Confidence Score: 1/5</h3>

Not safe to merge — two P0 regressions in corporate/lib/activity.py will break all activity table rendering at runtime.

Two P0 bugs in corporate/lib/activity.py: incorrect dict literal keys (variables used instead of string literals) and a changed render_to_string context that breaks the template namespace. Both affect every call to make_table, which is a core rendering path used throughout the activity views.

corporate/lib/activity.py — the make_table function has two critical bugs introduced by the autofix.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| corporate/lib/activity.py | Two P0 regressions introduced by the autofix: dict literal uses variable references as keys instead of string literals (breaking all activity table context), and the render_to_string call drops the wrapping dict, changing the template context namespace. |
| analytics/views/stats.py | C408 fixes are correct: dict() calls converted to literal syntax with proper string keys; dropping the named context argument is safe since the dict maps to the third positional parameter in Django's render(). |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["make_table(title, cols, rows, ...)"] --> B["Build data dict"]
    B --> C{"Correct keys?"}
    C -- "BEFORE fix: dict(title=title, ...) keys: 'title','cols',..." --> D["render_to_string(template, dict(data=data))"]
    C -- "AFTER autofix: {title: title, ...} keys: value-of-title,..." --> E["render_to_string(template, data) - wrong namespace"]
    D --> F["Template: data.title resolves correctly"]
    E --> G["Template: data.title fails - KeyError or empty"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve 9 ruff-c408 findings"](https://github.com/vikasagarwal101/zulip/commit/ab100c76fee08733c6a54c667d848853e386edb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30728647)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->