### PR TITLE
fix: resolve 9 ruff-c408 findings

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -91,11 +91,11 @@ def render_stats(
     return render(
         request,
         "analytics/stats.html",
-        context=dict(
-            target_name=title,
-            page_params=page_params,
-            analytics_ready=analytics_ready,
-        ),
+        context={
+            "target_name": title,
+            "page_params": page_params,
+            "analytics_ready": analytics_ready,
+        },
     )
 
 

--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -55,17 +55,17 @@ def make_table(
     if not has_row_class:
 
         def fix_row(row: Any) -> dict[str, Any]:
-            return dict(cells=row, row_class=None)
+            return {"cells": row, "row_class": None}
 
         rows = list(map(fix_row, rows))
 
-    data = dict(
-        title=title, cols=cols, rows=rows, header=header, totals=totals, title_link=title_link
-    )
+    data = {
+        title: title, cols: cols, rows: rows, header: header, totals: totals, title_link: title_link
+    }
 
     content = loader.render_to_string(
         "corporate/activity/activity_table.html",
-        dict(data=data),
+        {"data": data},
     )
 
     return content
@@ -118,7 +118,7 @@ def format_none_as_zero(value: int | None) -> int:
 def user_activity_link(link_text: str, user_profile_id: int) -> Markup:
     from corporate.views.user_activity import get_user_activity
 
-    url = reverse(get_user_activity, kwargs=dict(user_profile_id=user_profile_id))
+    url = reverse(get_user_activity, kwargs={"user_profile_id": user_profile_id})
     if link_text == "":
         return Markup('<a href="{url}"><i class="fa fa-user-circle"></i></a>').format(url=url)
     return Markup('<a href="{url}">{link_text}</a>').format(url=url, link_text=link_text)
@@ -127,14 +127,14 @@ def user_activity_link(link_text: str, user_profile_id: int) -> Markup:
 def realm_activity_link(realm_str: str) -> Markup:
     from corporate.views.realm_activity import get_realm_activity
 
-    url = reverse(get_realm_activity, kwargs=dict(realm_str=realm_str))
+    url = reverse(get_realm_activity, kwargs={"realm_str": realm_str})
     return Markup('<a href="{url}"><i class="fa fa-table"></i></a>').format(url=url)
 
 
 def realm_stats_link(realm_str: str) -> Markup:
     from analytics.views.stats import stats_for_realm
 
-    url = reverse(stats_for_realm, kwargs=dict(realm_str=realm_str))
+    url = reverse(stats_for_realm, kwargs={"realm_str": realm_str})
     return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a>').format(url=url)
 
 
@@ -157,7 +157,7 @@ def realm_url_link(realm_str: str) -> Markup:
 def remote_installation_stats_link(server_id: int) -> Markup:
     from analytics.views.stats import stats_for_remote_installation
 
-    url = reverse(stats_for_remote_installation, kwargs=dict(remote_server_id=server_id))
+    url = reverse(stats_for_remote_installation, kwargs={"remote_server_id": server_id})
     return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a>').format(url=url)
 
 


### PR DESCRIPTION
## **User description**
## Batch Fix: 9 ruff-c408 findings

This PR resolves 9 findings of type `ruff-c408` across 2 files.

### Findings

| # | File | Line | Issue |
|---|------|------|-------|
| 1 | `analytics/views/stats.py` | 83 | [#89](...) |
| 2 | `analytics/views/stats.py` | 94 | [#90](...) |
| 3 | `corporate/lib/activity.py` | 58 | [#93](...) |
| 4 | `corporate/lib/activity.py` | 62 | [#94](...) |
| 5 | `corporate/lib/activity.py` | 68 | [#95](...) |
| 6 | `corporate/lib/activity.py` | 121 | [#96](...) |
| 7 | `corporate/lib/activity.py` | 130 | [#97](...) |
| 8 | `corporate/lib/activity.py` | 137 | [#98](...) |
| 9 | `corporate/lib/activity.py` | 160 | [#99](...) |

### Scope
- Files changed: 2
- Fix method: autofix

### Verification
- [ ] All target detectors no longer fire
- [ ] No baseline regressions

---
*Generated by qa-agent batch PR engine*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies automated `ruff-C408` fixes to replace `dict(k=v)` constructor calls with literal `{"k": v}` syntax across two files. While 8 of the 9 conversions are correct, one introduces a critical runtime bug.

- In `corporate/lib/activity.py` line 62, `dict(title=title, cols=cols, rows=rows, ...)` was incorrectly converted to `{title: title, cols: cols, rows: rows, ...}`, using variables as dictionary keys instead of string literals. This will raise `TypeError: unhashable type: 'list'` when `cols` is a list (the typical case), crashing any page that calls `make_table`.
</details>

<h3>Confidence Score: 1/5</h3>

Not safe to merge — contains a P0 runtime crash in `make_table` that affects all activity pages.

A single P0 finding in `corporate/lib/activity.py` will cause a `TypeError` (unhashable type) at runtime on every call to `make_table`, breaking all corporate activity views. This requires a fix before merging.

corporate/lib/activity.py — the `data` dict at line 62 uses variables as keys instead of string literals.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| corporate/lib/activity.py | 7 of 8 C408 fixes are correct; one critical regression: `data = {title: title, cols: cols, ...}` uses variables as keys instead of string literals, causing a `TypeError` on list-typed `cols` and breaking template rendering. |
| analytics/views/stats.py | Both C408 fixes correctly convert `dict(k=v)` to `{"k": v}` with properly quoted string keys — no issues. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve 9 ruff-c408 findings"](https://github.com/vikasagarwal101/zulip/commit/4c3b68eda4470ef4b280c4a1e178fe894f2eca8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30774939)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->


___

## **CodeAnt-AI Description**
**Fix broken activity and stats page rendering**

### What Changed
- Restored correct data handling in activity tables so pages can render without crashing
- Fixed link generation for user, realm, remote installation, and stats pages so navigation opens the intended records
- Kept the stats page context format consistent when rendering the analytics view

### Impact
`✅ Fewer activity page crashes`
`✅ Working links to user and realm details`
`✅ Reliable stats page loading`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=xxaS3IR7EsA42HfLUTy90ussURU2aQPxaxX64KvTQjw&org=vikasagarwal101)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
